### PR TITLE
Update path for mullvad-daemon

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ url='https://github.com/voj343/mullvad-openrc'
 license=('GPL')
 depends=('openrc')
 source=("mullvadd.initd")
-sha256sums=("17043deeb5144a624bcbc08bed7b0aa08379c1c849d1d2ceecdcdc34d022435b")
+sha256sums=("3c0d6016088c969d8f89339069e5b83503f5e434b0b811ff1d7e2197063a3f73")
 
 package() {
   install -Dm755 ${srcdir}/mullvadd.initd "$pkgdir"/etc/init.d/mullvadd

--- a/mullvadd.initd
+++ b/mullvadd.initd
@@ -6,7 +6,7 @@ depend() {
 }
 
 supervisor="supervise-daemon"
-command="/opt/Mullvad\ VPN/resources/mullvad-daemon"
+command="/usr/bin/mullvad-daemon"
 command_args="${MULLVPN_OPTS}"
 pidfile="/run/${RC_SVCNAME}.pid"
 command_background=true


### PR DESCRIPTION
In release 2022.5, the path to the mullvad-daemon binary was changed from `/opt/Mullvad VPN/resources/mullvad-daemon` to `/usr/bin/mullvad-daemon`

under Changed->linux sections: https://github.com/mullvad/mullvadvpn-app/releases/tag/2022.5